### PR TITLE
Dynamically set redis `log_level` to 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Compatible with Magento 2.4.1 and higher.
 - Bundled in this module is a cache decorator which will add to the vanilla offering of logging `cache_invalidate` with `cache_load` and `cache_save` information.
   - This uses a virtual type `Ampersand\VerboseLogRequest\Logger\VerboseDebugLogger` which calls to `->debug()` on the `Psr\Log\LoggerInterface`.
   - See `src/CacheDecorator/VerboseLogger.php`
+- Set redis log level to debug mode (level 7)
+  - Allows you to see redis locks etc 
+  - TODO cache log level as well as session log level
 
 ## Example Usage
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,10 @@ Compatible with Magento 2.4.1 and higher.
 - Bundled in this module is a cache decorator which will add to the vanilla offering of logging `cache_invalidate` with `cache_load` and `cache_save` information.
   - This uses a virtual type `Ampersand\VerboseLogRequest\Logger\VerboseDebugLogger` which calls to `->debug()` on the `Psr\Log\LoggerInterface`.
   - See `src/CacheDecorator/VerboseLogger.php`
-- Set redis log level to debug mode (level 7)
-  - Allows you to see redis locks etc 
-  - TODO cache log level as well as session log level
+- Set redis session log level to debug mode (level 7)
+  - Allows you to see redis lock acquisitions, lock waits, zombie processes, etc
+  - https://github.com/colinmollenhour/Cm_RedisSession#configuration-example
 
-## Example Usage
-
-On the system you want to debug run the following command to get the current key
 ```
 $ php bin/magento ampersand:verbose-log-request:get-key
 The current key is:               d07c0ee76154d48c2974516ef22c1ec0

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Compatible with Magento 2.4.1 and higher.
   - Allows you to see redis lock acquisitions, lock waits, zombie processes, etc
   - https://github.com/colinmollenhour/Cm_RedisSession#configuration-example
 
+## Example Usage
+
+On the system you want to debug run the following command to get the current key
+
 ```
 $ php bin/magento ampersand:verbose-log-request:get-key
 The current key is:               d07c0ee76154d48c2974516ef22c1ec0

--- a/src/Plugin/AdjustRedisLogLevel.php
+++ b/src/Plugin/AdjustRedisLogLevel.php
@@ -31,7 +31,12 @@ class AdjustRedisLogLevel
     public function afterGetLogLevel(RedisConfig $subject, $result)
     {
         if ($this->isVerbose->isVerbose()) {
-            return '7777';
+            /**
+             * 7 (debug: the most information for development/testing)
+             *
+             * @link https://github.com/colinmollenhour/Cm_RedisSession#configuration-example
+             */
+            return '7';
         }
         return $result;
     }

--- a/src/Plugin/AdjustRedisLogLevel.php
+++ b/src/Plugin/AdjustRedisLogLevel.php
@@ -36,7 +36,7 @@ class AdjustRedisLogLevel
              *
              * @link https://github.com/colinmollenhour/Cm_RedisSession#configuration-example
              */
-            return '77777';
+            return '7';
         }
         return $result;
     }

--- a/src/Plugin/AdjustRedisLogLevel.php
+++ b/src/Plugin/AdjustRedisLogLevel.php
@@ -31,7 +31,7 @@ class AdjustRedisLogLevel
     public function afterGetLogLevel(RedisConfig $subject, $result)
     {
         if ($this->isVerbose->isVerbose()) {
-            return '7';
+            return '7777';
         }
         return $result;
     }

--- a/src/Plugin/AdjustRedisLogLevel.php
+++ b/src/Plugin/AdjustRedisLogLevel.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+namespace Ampersand\VerboseLogRequest\Plugin;
+
+use Ampersand\VerboseLogRequest\Service\IsVerbose;
+use Magento\Framework\Session\SaveHandler\Redis\Config as RedisConfig;
+
+class AdjustRedisLogLevel
+{
+    /**
+     * @var IsVerbose
+     */
+    private IsVerbose $isVerbose;
+
+    /**
+     * @param IsVerbose $isVerbose
+     */
+    public function __construct(
+        IsVerbose $isVerbose
+    ) {
+        $this->isVerbose = $isVerbose;
+    }
+
+    /**
+     * Bump redis log level to 7 when on a verbose request.
+     *
+     * @param RedisConfig $subject
+     * @param string $result
+     * @return mixed|string
+     */
+    public function afterGetLogLevel(RedisConfig $subject, $result)
+    {
+        if ($this->isVerbose->isVerbose()) {
+            return '7';
+        }
+        return $result;
+    }
+}

--- a/src/Plugin/AdjustRedisLogLevel.php
+++ b/src/Plugin/AdjustRedisLogLevel.php
@@ -36,7 +36,7 @@ class AdjustRedisLogLevel
              *
              * @link https://github.com/colinmollenhour/Cm_RedisSession#configuration-example
              */
-            return '7';
+            return '77777';
         }
         return $result;
     }

--- a/src/Test/Integration/RedisLogLevelTest.php
+++ b/src/Test/Integration/RedisLogLevelTest.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Ampersand\VerboseLogRequest\Test\Integration;
+
+use Magento\Framework\Session\SaveHandler\Redis\Config as RedisConfig;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+class RedisLogLevelTest extends TestCase
+{
+    public function testGetDefaultLogLevel()
+    {
+        $redisConfig = Bootstrap::getObjectManager()->get(RedisConfig::class);
+        $this->assertEquals('asdf', $redisConfig->getLogLevel());
+    }
+
+    public function testGetVerboseLogLevel()
+    {
+        $this->markTestSkipped('TODO');
+        $redisConfig = Bootstrap::getObjectManager()->get(RedisConfig::class);
+        $this->assertEquals('asdf', $redisConfig->getLogLevel());
+    }
+}

--- a/src/Test/Integration/RedisLogLevelTest.php
+++ b/src/Test/Integration/RedisLogLevelTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Ampersand\VerboseLogRequest\Test\Integration;
 
+use Ampersand\VerboseLogRequest\Service\IsVerbose\Storage;
 use Magento\Framework\Session\SaveHandler\Redis\Config as RedisConfig;
 use Magento\TestFramework\Helper\Bootstrap;
 use PHPUnit\Framework\TestCase;
@@ -12,13 +13,14 @@ class RedisLogLevelTest extends TestCase
     public function testGetDefaultLogLevel()
     {
         $redisConfig = Bootstrap::getObjectManager()->get(RedisConfig::class);
-        $this->assertEquals('asdf', $redisConfig->getLogLevel());
+        $this->assertNull($redisConfig->getLogLevel(), 'Default log level is not null');
     }
 
     public function testGetVerboseLogLevel()
     {
-        $this->markTestSkipped('TODO');
+        Storage::setFlag(true, true);
         $redisConfig = Bootstrap::getObjectManager()->get(RedisConfig::class);
-        $this->assertEquals('asdf', $redisConfig->getLogLevel());
+        $this->assertEquals('7', $redisConfig->getLogLevel(), 'Default log level is not 7');
+        Storage::reset(true);
     }
 }

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -42,7 +42,7 @@
         </arguments>
     </type>
 
-    <type name="\Magento\Framework\Session\SaveHandler\Redis\Config">
+    <type name="Cm\RedisSession\Handler\ConfigInterface">
         <plugin name="ampersand_verboselogrequest_adjust_redis_log_level" type="\Ampersand\VerboseLogRequest\Plugin\AdjustRedisLogLevel" sortOrder="1" disabled="false" />
     </type>
 

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -41,4 +41,9 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="\Magento\Framework\Session\SaveHandler\Redis\Config">
+        <plugin name="ampersand_verboselogrequest_adjust_redis_log_level" type="\Ampersand\VerboseLogRequest\Plugin\AdjustRedisLogLevel" sortOrder="1" disabled="false" />
+    </type>
+
 </config>


### PR DESCRIPTION
Dynamically set the log level for redis sessions to `7` so that we get all the fun logging like this

https://github.com/colinmollenhour/magento-lite/blob/170864c3b763f16d059331d68154ff1c22fb5b11/app/code/community/Cm/RedisSession/Model/Session.php#L146

```
[2022-11-30 20:26:08] report.DEBUG: 69095: Connected to Redis /some/url/ 
[2022-11-30 20:26:08] report.DEBUG: 69095: Cm\RedisSession\Handler initialized for connection to 0.0.0.0:1234 after 0.00612 seconds /some/url/ 
[2022-11-30 20:26:08] report.DEBUG: 69095: Attempting to take lock on ID sess_91ctlqu6cklsa7t7nrofjn4f09 /some/url/ 
[2022-11-30 20:26:08] report.DEBUG: 69095: Data read for ID sess_91ctlqu6cklsa7t7nrofjn4f09 in 0.00242 seconds /some/url/ 
[2022-11-30 20:26:25] report.DEBUG: 69095: Data written to ID 91ctlqu6cklsa7t7nrofjn4f09 in 0.00938 seconds /some/url/ 
[2022-11-30 20:26:25] report.DEBUG: 69095: Closing connection /some/url/ 
```